### PR TITLE
Use FQDN for binding Client class

### DIFF
--- a/src/ServiceProviderLaravel5.php
+++ b/src/ServiceProviderLaravel5.php
@@ -43,6 +43,6 @@ class ServiceProviderLaravel5 extends \Illuminate\Support\ServiceProvider
             );
         });
 
-        $this->app->bind(Maknz\Slack\Client::class, 'maknz.slack');
+        $this->app->bind(Client::class, 'maknz.slack');
     }
 }


### PR DESCRIPTION
Laravel was unable to bind the Client class with the corresponding singleton container because when using the `::class` notation we need to add a forward slash into the namespace. Without this change instantiating a `Client` object inside our application resulted in a BindingResolutionException.